### PR TITLE
Relax type constraint on TransformByFunction

### DIFF
--- a/jmespath-core/src/main/java/io/burt/jmespath/function/TransformByFunction.java
+++ b/jmespath-core/src/main/java/io/burt/jmespath/function/TransformByFunction.java
@@ -13,7 +13,7 @@ import io.burt.jmespath.Expression;
 public abstract class TransformByFunction extends BaseFunction {
   public TransformByFunction() {
     super(
-      ArgumentConstraints.arrayOf(ArgumentConstraints.typeOf(JmesPathType.OBJECT)),
+      ArgumentConstraints.arrayOf(ArgumentConstraints.typeOf(JmesPathType.ARRAY, JmesPathType.OBJECT)),
       ArgumentConstraints.expression()
     );
   }

--- a/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
+++ b/jmespath-core/src/test/java/io/burt/jmespath/JmesPathRuntimeTest.java
@@ -1589,7 +1589,7 @@ public abstract class JmesPathRuntimeTest<T> {
       search("max_by(@, &foo)", parse("{}"));
       fail("Expected ArgumentTypeException to have been thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("expected array of object but was object"));
+      assertThat(ate.getMessage(), containsString("expected array of array or object but was object"));
     }
   }
 
@@ -1599,7 +1599,7 @@ public abstract class JmesPathRuntimeTest<T> {
       search("max_by(&foo, @)", parse("[]"));
       fail("Expected ArgumentTypeException to have been thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("expected array of object but was expression"));
+      assertThat(ate.getMessage(), containsString("expected array of array or object but was expression"));
     }
   }
 
@@ -1793,7 +1793,7 @@ public abstract class JmesPathRuntimeTest<T> {
       search("min_by(@, &foo)", parse("{}"));
       fail("Expected ArgumentTypeException to have been thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("expected array of object but was object"));
+      assertThat(ate.getMessage(), containsString("expected array of array or object but was object"));
     }
   }
 
@@ -1803,7 +1803,7 @@ public abstract class JmesPathRuntimeTest<T> {
       search("min_by(&foo, @)", parse("[]"));
       fail("Expected ArgumentTypeException to have been thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("expected array of object but was expression"));
+      assertThat(ate.getMessage(), containsString("expected array of array or object but was expression"));
     }
   }
 
@@ -2024,7 +2024,7 @@ public abstract class JmesPathRuntimeTest<T> {
 
   @Test
   public void sortBySortsTheInputBasedOnNumbersReturnedByAnExpression() {
-    T result = search("sort_by(@, &foo)[*].foo", parse("[{\"foo\": 3}, {\"foo\": -6}, {\"foo\": 1}]"));
+    T result = search("sort_by(@, &[1])[*][1]", parse("[[\"foo\", 3], [\"foo\", -6], [\"foo\", 1]]"));
     assertThat(result, is(parse("[-6, 1, 3]")));
   }
 
@@ -2072,7 +2072,7 @@ public abstract class JmesPathRuntimeTest<T> {
       search("sort_by(@, &foo)", parse("{}"));
       fail("Expected ArgumentTypeException to have been thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("expected array of object but was object"));
+      assertThat(ate.getMessage(), containsString("expected array of array or object but was object"));
     }
   }
 
@@ -2082,7 +2082,7 @@ public abstract class JmesPathRuntimeTest<T> {
       search("sort_by(&foo, @)", parse("[]"));
       fail("Expected ArgumentTypeException to have been thrown");
     } catch (ArgumentTypeException ate) {
-      assertThat(ate.getMessage(), containsString("expected array of object but was expression"));
+      assertThat(ate.getMessage(), containsString("expected array of array or object but was expression"));
     }
   }
 


### PR DESCRIPTION
TransformByFunction asks for an array of objects, but nothing is preventing it from also working on arrays of arrays.

The JMESPath specification and the compliance test suite do not mandate the first argument to be an array of objects.